### PR TITLE
Update dev tutorial with kyma default domain

### DIFF
--- a/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-01-expose-workload-apigateway.md
+++ b/docs/03-tutorials/00-api-exposure/apix-04-expose-workload/apix-04-01-expose-workload-apigateway.md
@@ -31,7 +31,7 @@ This tutorial shows how to expose an unsecured instance of the HttpBin service o
     </summary>
 
     ```bash
-    export DOMAIN_TO_EXPOSE_WORKLOADS={KYMA_DOMAIN_NAME}
+    export DOMAIN_TO_EXPOSE_WORKLOADS=local.kyma.dev
     export GATEWAY=kyma-system/kyma-gateway
     ```
     </details>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- as developer I followed the tutorial step by step until I reached the point where I was struggeling with the API and workload exposure because I was looking for the default kyma domain

I adjusted the part where the devloper can simply copy and paste the the command directly if he hasn't adjusted or customized his own DNS 
